### PR TITLE
Add support for GN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ See also [https://github.com/dnut/rewrap/releases](https://github.com/dnut/rewra
 
 ---
 
+### Unreleased
+
+- Add GN language (#342)
+
 
 ### 1.16.3
 

--- a/core/Parsing.Documents.fs
+++ b/core/Parsing.Documents.fs
@@ -119,6 +119,7 @@ let mutable languages = [
     lang "FIDL" "" ".fidl" <| sc [line "///?"]
     lang "Go" "" ".go" <| sc [block' ("", "") (@"/\*", @"\*/") godoc; line' "//" godoc]
     lang "Git commit" "git-commit" "tag_editmsg" <| docOf markdown
+    lang "GN" "" ".gn|.gni" <| configFile
     lang "GraphQL" "" ".graphql|.gql" <| sc [line "#"; block (@".*?""""""", "\"\"\"")]
     lang "Groovy" "" ".groovy" java
     lang "Handlebars" "" ".handlebars|.hbs" <| sc [block ("{{!--", "--}}"); block ("{{!", "}}"); block ("<!--", "-->")]


### PR DESCRIPTION
GN is a build system used by Chromium and some other projects: https://gn.googlesource.com/gn/

It uses # for comments:
https://gn.googlesource.com/gn/+/main/docs/reference.md#white-space-and-comments

h/t @mk12