### PR TITLE
Update json5 to 2.2.3 to fix CVE-2022-46175

### DIFF
--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "fast-diff": "^1.2.0",
-        "json5": "^2.2.0",
+        "json5": "^2.2.3",
         "localtunnel": "^2.0.2",
         "serve": "^13.0.2"
       },
@@ -608,13 +608,10 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -1573,13 +1570,10 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
     },
     "localtunnel": {
       "version": "2.0.2",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -128,7 +128,7 @@
   },
   "devDependencies": {
     "fast-diff": "^1.2.0",
-    "json5": "^2.2.0",
+    "json5": "^2.2.3",
     "localtunnel": "^2.0.2",
     "serve": "^13.0.2"
   },


### PR DESCRIPTION
json5 versions before 2.2.2 are vulnerable to prototype pollution via the parse method (CVE-2022-46175). Update the dependency and refresh the lockfile.